### PR TITLE
Fix gtk path

### DIFF
--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -213,7 +213,7 @@ case "$DEPLOY_GTK_VERSION" in
         copy_tree "$gtk3_libdir" "$APPDIR/"
         cat >> "$HOOKFILE" <<EOF
 export GTK_EXE_PREFIX="\$APPDIR/$gtk3_exec_prefix"
-export GTK_PATH="\$APPDIR/$gtk3_libdir"
+export GTK_PATH="\$APPDIR/$gtk3_libdir:/usr/lib64/gtk-3.0:/usr/lib/x86_64-linux-gnu/gtk-3.0"
 export GTK_IM_MODULE_FILE="\$APPDIR/$gtk3_immodules_cache_file"
 
 EOF

--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -205,7 +205,7 @@ case "$DEPLOY_GTK_VERSION" in
         echo "Installing GTK 3.0 modules"
         gtk3_exec_prefix="$(get_pkgconf_variable "exec_prefix" "gtk+-3.0")"
         gtk3_libdir="$(get_pkgconf_variable "libdir" "gtk+-3.0")/gtk-3.0"
-        gtk3_path="$gtk3_libdir/modules"
+        #gtk3_path="$gtk3_libdir/modules" export GTK_PATH="\$APPDIR/$gtk3_path"
         gtk3_immodulesdir="$gtk3_libdir/$(get_pkgconf_variable "gtk_binary_version" "gtk+-3.0")/immodules"
         gtk3_printbackendsdir="$gtk3_libdir/$(get_pkgconf_variable "gtk_binary_version" "gtk+-3.0")/printbackends"
         gtk3_immodules_cache_file="$(dirname "$gtk3_immodulesdir")/immodules.cache"
@@ -213,7 +213,7 @@ case "$DEPLOY_GTK_VERSION" in
         copy_tree "$gtk3_libdir" "$APPDIR/"
         cat >> "$HOOKFILE" <<EOF
 export GTK_EXE_PREFIX="\$APPDIR/$gtk3_exec_prefix"
-export GTK_PATH="\$APPDIR/$gtk3_path"
+export GTK_PATH="\$APPDIR/$gtk3_libdir"
 export GTK_IM_MODULE_FILE="\$APPDIR/$gtk3_immodules_cache_file"
 
 EOF


### PR DESCRIPTION
This PR is about the `Gtk-Message: Failed to load module X` warnings.

- first commit: removed the `modules` path segment from `GTK_PATH` so that it can actually find the modules folder
- second commit: i added 2 common _absolute_ paths of the modules folder so that gtk can fall back to modules present on the user's system since there are files we just can't bundle (and we don't know which ones are needed either since they are requested by the system, not the appimage).
  - The only concern i had here were version conflicts, but i did quite extensive testing and wasn't able to find _any_ problems. Therefore i'm just gonna use the release candidate for a live test.