### PR TITLE
Fix symbolic link command to force overwrite

### DIFF
--- a/linuxdeploy-plugin-gtk.sh
+++ b/linuxdeploy-plugin-gtk.sh
@@ -305,7 +305,7 @@ PATCH_ARRAY=(
 )
 for directory in "${PATCH_ARRAY[@]}"; do
     while IFS= read -r -d '' file; do
-        ln $verbose -s "${file/\/usr\/lib\//}" "$APPDIR/usr/lib"
+        ln $verbose -sf "${file/\/usr\/lib\//}" "$APPDIR/usr/lib"
     done < <(find "$directory" -name '*.so' -print0)
 done
 


### PR DESCRIPTION
The original `ln -s` is vulnerable, which just returns a error when meeting files already exist. 
After adding the `-f` flag, this script can handle link error in a more robust way.
```
     -f, --force
            remove existing destination files

```